### PR TITLE
Mastery levels ordering UX on evaluation creation

### DIFF
--- a/app/components/EvaluationConfigMasteryLevelOption.vue
+++ b/app/components/EvaluationConfigMasteryLevelOption.vue
@@ -1,0 +1,50 @@
+<script setup lang="ts">
+defineProps<{
+  handleClass: string
+}>()
+
+const emit = defineEmits<{
+  (e: 'remove'): void
+}>()
+
+const label = defineModel<string>('label')
+const description = defineModel<string>('description')
+
+const { t } = useI18n()
+</script>
+
+<template>
+  <div class="flex gap-2 w-full pl-1.5 pr-3 py-3 rounded-lg bg-neutral-100">
+    <UIcon
+      name="i-lucide-grip-vertical"
+      :class="handleClass"
+      class="size-5 text-neutral-500 cursor-grab hover:text-neutral-700
+      transition-colors duration-150"
+    />
+
+    <div class="flex-1">
+      <div class="flex items-center gap-3 mb-2">
+        <UInput
+          v-model="label"
+          :placeholder="t('configuration.modal.fields.levelName')"
+          class="flex-1"
+        />
+        <!-- Delete action -->
+        <UButton
+          icon="i-lucide:trash-2"
+          color="error"
+          variant="ghost"
+          size="sm"
+          @click="emit('remove')"
+        />
+      </div>
+
+      <UTextarea
+        v-model="description"
+        :rows="1"
+        :placeholder="t('configuration.modal.fields.levelDescription')"
+        class="w-full"
+      />
+    </div>
+  </div>
+</template>

--- a/app/components/EvaluationConfigModal.vue
+++ b/app/components/EvaluationConfigModal.vue
@@ -37,21 +37,6 @@ watch(() => props.modelValue, (newConfig) => {
   }
 }, { immediate: true, deep: true })
 
-// Reset state when modal closes
-watch(isOpen, (isOpenNow) => {
-  if (!isOpenNow) {
-    // Reset all state when modal is closed
-    localConfig.value = null
-    validationErrors.value = []
-    isSaving.value = false
-    activeTab.value = 'basic'
-  }
-})
-
-const currentMasteryLevels = computed(() =>
-  localConfig.value?.settings.masterySettings?.levels ?? [],
-)
-
 // Evaluation type options
 const evaluationTypes: ComputedRef<Array<{ value: EvaluationType, label: string, description: string }>> = computed(() => [
   {
@@ -127,48 +112,33 @@ function removeMasteryLevel(index: number) {
   localConfig.value.settings.masterySettings.levels.splice(index, 1)
 }
 
-function swapOrders(levels: Array<{ order: number }>, index1: number, index2: number) {
-  if (index1 < 0 || index2 < 0 || index1 >= levels.length || index2 >= levels.length) {
-    return
-  }
-
-  const level1 = levels[index1]
-  const level2 = levels[index2]
-
-  if (!level1 || !level2) {
-    return
-  }
-
-  // Swap the order values
-  const temp = level1.order
-  level1.order = level2.order
-  level2.order = temp
-
-  // Sort the array by order to reflect the new positions
-  levels.sort((a, b) => a.order - b.order)
-}
-
-// Swap mastery levels
-function swapMasteryLevels(index1: number, index2: number) {
-  if (!localConfig.value?.settings.masterySettings?.levels) {
-    return
-  }
-  swapOrders(localConfig.value.settings.masterySettings.levels, index1, index2)
-}
-
 // Swap mastery levels with drag-and-drop
 const dragAndDropHandle = 'grip'
 const masteryLevelsList = useTemplateRef<HTMLElement>('masteryLevels')
-onMounted(() => {
-  // FIXME not working at all
-  useSortable<MasteryLevelDefinition>(
-    masteryLevelsList,
-    currentMasteryLevels,
-    {
-      animation: 200,
-      handle: `.${dragAndDropHandle}`, // allow dragging only with the handle
-    },
-  )
+const sortableInstance = ref<ReturnType<typeof useSortable> | null>(null)
+
+watch([isOpen, masteryLevelsList], async ([isOpenNow, list]) => {
+  if (isOpenNow && list) { // list initialized after DOM rendering
+    await nextTick()
+
+    // Initialize drag-and-drop swapping
+    sortableInstance.value = useSortable<MasteryLevelDefinition>(
+      list,
+      localConfig.value?.settings.masterySettings?.levels ?? [],
+      {
+        animation: 200,
+        handle: `.${dragAndDropHandle}`, // allow dragging only with the handle
+      },
+    )
+  }
+  else {
+    // Reset all state when modal is closed
+    localConfig.value = null
+    validationErrors.value = []
+    isSaving.value = false
+    activeTab.value = 'basic'
+    sortableInstance.value = null
+  }
 })
 </script>
 
@@ -253,9 +223,8 @@ onMounted(() => {
                     <ul ref="masteryLevels" class="space-y-3">
                       <!-- TODO fix modal height with scroll when too much elements -->
                       <li
-                        v-for="(level, index) in currentMasteryLevels"
+                        v-for="(level, index) in localConfig.settings.masterySettings.levels"
                         :key="level.id"
-                        class="flex flex-col gap-0 items-center"
                       >
                         <div class="flex w-full gap-3">
                           <span class="mt-1.5">
@@ -269,13 +238,6 @@ onMounted(() => {
                             @remove="removeMasteryLevel(index)"
                           />
                         </div>
-
-                        <UButton
-                          v-if="index < currentMasteryLevels.length - 1"
-                          class="mt-2" size="lg" variant="ghost"
-                          icon="i-lucide:arrow-up-down"
-                          @click="swapMasteryLevels(index, index + 1)"
-                        />
                       </li>
                     </ul>
                   </div>

--- a/app/components/EvaluationConfigModal.vue
+++ b/app/components/EvaluationConfigModal.vue
@@ -220,8 +220,7 @@ watch([isOpen, masteryLevelsList], async ([isOpenNow, list]) => {
                       </UButton>
                     </div>
 
-                    <ul ref="masteryLevels" class="space-y-3">
-                      <!-- TODO fix modal height with scroll when too much elements -->
+                    <ul ref="masteryLevels" class="space-y-3 max-h-[50vh] overflow-y-auto">
                       <li
                         v-for="(level, index) in localConfig.settings.masterySettings.levels"
                         :key="level.id"

--- a/app/components/EvaluationConfigModal.vue
+++ b/app/components/EvaluationConfigModal.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { EvaluationConfig, EvaluationType, MasteryLevelDefinition } from '@/models/index'
+import type { EvaluationConfig, EvaluationType, MasteryLevelDefinition } from '~/models'
 import { useSortable } from '@vueuse/integrations/useSortable'
 
 const props = defineProps<{

--- a/app/components/EvaluationConfigModal.vue
+++ b/app/components/EvaluationConfigModal.vue
@@ -47,6 +47,10 @@ watch(isOpen, (isOpenNow) => {
   }
 })
 
+const currentMasteryLevels = computed(() =>
+  localConfig.value?.settings.masterySettings?.levels ?? [],
+)
+
 // Evaluation type options
 const evaluationTypes: ComputedRef<Array<{ value: EvaluationType, label: string, description: string }>> = computed(() => [
   {
@@ -150,6 +154,10 @@ function swapMasteryLevels(index1: number, index2: number) {
   }
   swapOrders(localConfig.value.settings.masterySettings.levels, index1, index2)
 }
+
+// Swap mastery levels with drag-and-drop
+const dragAndDropHandle = 'grip'
+const masteryLevelsList = useTemplateRef<HTMLElement>('masteryLevels')
 </script>
 
 <template>
@@ -227,25 +235,23 @@ function swapMasteryLevels(index1: number, index2: number) {
                     </div>
 
                     <div class="space-y-3">
+                      <!-- TODO fix modal height with scroll when too much elements -->
                       <div
                         v-for="(level, index) in localConfig.settings.masterySettings.levels"
-                        :key="level.id" class="flex flex-col gap-0 items-center"
+                        :key="level.id"
+                        ref="masteryLevels"
+                        class="flex flex-col gap-0 items-center"
                       >
-                        <div class="w-full">
-                          <div class="flex items-center gap-3 mb-2">
-                            <UInput
-                              v-model="level.label" :placeholder="t('configuration.modal.fields.levelName')"
-                              class="flex-1"
-                            />
-                            <UButton
-                              icon="i-lucide:trash-2" color="error" variant="ghost"
-                              size="sm" @click="removeMasteryLevel(index)"
-                            />
-                          </div>
-
-                          <UTextarea
-                            v-model="level.description" :rows="1"
-                            :placeholder="t('configuration.modal.fields.levelDescription')" class="w-full"
+                        <div class="flex w-full gap-3">
+                          <span class="mt-1.5">
+                            {{ index + 1 }}.
+                          </span>
+                          <EvaluationConfigMasteryLevelOption
+                            v-model:label="level.label"
+                            v-model:description="level.description"
+                            :handle-class="dragAndDropHandle"
+                            class="flex-1"
+                            @remove="removeMasteryLevel(index)"
                           />
                         </div>
 

--- a/app/components/EvaluationConfigModal.vue
+++ b/app/components/EvaluationConfigModal.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import type { EvaluationConfig, EvaluationType } from '@/models/index'
+import type { EvaluationConfig, EvaluationType, MasteryLevelDefinition } from '@/models/index'
+import { useSortable } from '@vueuse/integrations/useSortable'
 
 const props = defineProps<{
   modelValue: EvaluationConfig | null
@@ -158,6 +159,17 @@ function swapMasteryLevels(index1: number, index2: number) {
 // Swap mastery levels with drag-and-drop
 const dragAndDropHandle = 'grip'
 const masteryLevelsList = useTemplateRef<HTMLElement>('masteryLevels')
+onMounted(() => {
+  // FIXME not working at all
+  useSortable<MasteryLevelDefinition>(
+    masteryLevelsList,
+    currentMasteryLevels,
+    {
+      animation: 200,
+      handle: `.${dragAndDropHandle}`, // allow dragging only with the handle
+    },
+  )
+})
 </script>
 
 <template>
@@ -209,7 +221,11 @@ const masteryLevelsList = useTemplateRef<HTMLElement>('masteryLevels')
               <template #basic>
                 <div class="space-y-4 mt-4">
                   <UFormField :label="t('configuration.modal.fields.configurationName')">
-                    <UInput v-model="localConfig.name" :placeholder="t('configuration.modal.fields.configurationNamePlaceholder')" class="w-full" />
+                    <UInput
+                      v-model="localConfig.name"
+                      :placeholder="t('configuration.modal.fields.configurationNamePlaceholder')"
+                      class="w-full"
+                    />
                   </UFormField>
                 </div>
               </template>
@@ -234,12 +250,11 @@ const masteryLevelsList = useTemplateRef<HTMLElement>('masteryLevels')
                       </UButton>
                     </div>
 
-                    <div class="space-y-3">
+                    <ul ref="masteryLevels" class="space-y-3">
                       <!-- TODO fix modal height with scroll when too much elements -->
-                      <div
-                        v-for="(level, index) in localConfig.settings.masterySettings.levels"
+                      <li
+                        v-for="(level, index) in currentMasteryLevels"
                         :key="level.id"
-                        ref="masteryLevels"
                         class="flex flex-col gap-0 items-center"
                       >
                         <div class="flex w-full gap-3">
@@ -256,13 +271,13 @@ const masteryLevelsList = useTemplateRef<HTMLElement>('masteryLevels')
                         </div>
 
                         <UButton
-                          v-if="index < localConfig.settings.masterySettings.levels.length - 1"
+                          v-if="index < currentMasteryLevels.length - 1"
                           class="mt-2" size="lg" variant="ghost"
                           icon="i-lucide:arrow-up-down"
                           @click="swapMasteryLevels(index, index + 1)"
                         />
-                      </div>
-                    </div>
+                      </li>
+                    </ul>
                   </div>
 
                   <!-- Boolean Configuration -->

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,10 @@
         "@nuxt/ui": "^3.1.2",
         "@nuxtjs/i18n": "^9.5.4",
         "@vueuse/core": "^13.2.0",
+        "@vueuse/integrations": "^13.3.0",
         "@vueuse/nuxt": "^13.2.0",
         "nuxt": "^3.17.4",
+        "sortablejs": "^1.15.6",
         "vue": "^3.5.14"
       },
       "devDependencies": {
@@ -5655,13 +5657,13 @@
       }
     },
     "node_modules/@vueuse/integrations": {
-      "version": "13.2.0",
-      "resolved": "https://registry.npmjs.org/@vueuse/integrations/-/integrations-13.2.0.tgz",
-      "integrity": "sha512-tnwdzUYadAiewvMtBcjH/ZPgRCoQBvuVzbFA/VSysPDaIuG41Jp/Z1Sn/rYoFMOLJfcOEcVh+tN3mkrVIyumig==",
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/integrations/-/integrations-13.3.0.tgz",
+      "integrity": "sha512-h5mGRYPbiTZTFP/AKELLPGnUDBly7z7Qd1pgEQlT3ItQ0NlZM0vB+8SOQycpSBOBlgg72Zgw+mi2r+4O/G8RuQ==",
       "license": "MIT",
       "dependencies": {
-        "@vueuse/core": "13.2.0",
-        "@vueuse/shared": "13.2.0"
+        "@vueuse/core": "13.3.0",
+        "@vueuse/shared": "13.3.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
@@ -5718,6 +5720,44 @@
         "universal-cookie": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@vueuse/integrations/node_modules/@vueuse/core": {
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-13.3.0.tgz",
+      "integrity": "sha512-uYRz5oEfebHCoRhK4moXFM3NSCd5vu2XMLOq/Riz5FdqZMy2RvBtazdtL3gEcmDyqkztDe9ZP/zymObMIbiYSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/web-bluetooth": "^0.0.21",
+        "@vueuse/metadata": "13.3.0",
+        "@vueuse/shared": "13.3.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.0"
+      }
+    },
+    "node_modules/@vueuse/integrations/node_modules/@vueuse/metadata": {
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-13.3.0.tgz",
+      "integrity": "sha512-42IzJIOYCKIb0Yjv1JfaKpx8JlCiTmtCWrPxt7Ja6Wzoq0h79+YVXmBV03N966KEmDEESTbp5R/qO3AB5BDnGw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/integrations/node_modules/@vueuse/shared": {
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-13.3.0.tgz",
+      "integrity": "sha512-L1QKsF0Eg9tiZSFXTgodYnu0Rsa2P0En2LuLrIs/jgrkyiDuJSsPZK+tx+wU0mMsYHUYEjNsuE41uqqkuR8VhA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.0"
       }
     },
     "node_modules/@vueuse/metadata": {
@@ -14579,6 +14619,12 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/smob/-/smob-1.5.0.tgz",
       "integrity": "sha512-g6T+p7QO8npa+/hNx9ohv1E5pVCmWrVCUzUXJyLdMmftX6ER0oiWY/w9knEonLpnOp6b6FenKnMfR8gqwWdwig==",
+      "license": "MIT"
+    },
+    "node_modules/sortablejs": {
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.6.tgz",
+      "integrity": "sha512-aNfiuwMEpfBM/CN6LY0ibyhxPfPbyFeBTYJKCvzkJ2GkUpazIt3H+QIPAMHwqQ7tMKaHz1Qj+rJJCqljnf4p3A==",
       "license": "MIT"
     },
     "node_modules/source-map": {

--- a/package.json
+++ b/package.json
@@ -19,8 +19,10 @@
     "@nuxt/ui": "^3.1.2",
     "@nuxtjs/i18n": "^9.5.4",
     "@vueuse/core": "^13.2.0",
+    "@vueuse/integrations": "^13.3.0",
     "@vueuse/nuxt": "^13.2.0",
     "nuxt": "^3.17.4",
+    "sortablejs": "^1.15.6",
     "vue": "^3.5.14"
   },
   "devDependencies": {


### PR DESCRIPTION
Closes #4.

I used drag-and-drop to simplify the ordering.  

I've also added a hint to each level to make it easier to understand the order.  
To take things a step further, we could make it easier to understand the order by using colors: the higher the hint, the redder it is, and therefore the lower the level.