### PR TITLE
Display dataset context

### DIFF
--- a/app/components/ContextDataCollapsible.vue
+++ b/app/components/ContextDataCollapsible.vue
@@ -22,7 +22,10 @@ defineProps<{
     />
 
     <template #content>
-      <div class="bg-neutral-100 mt-1.5 rounded-md p-5 flex flex-col gap-4 text-sm">
+      <div
+        class="bg-neutral-100 mt-1.5 rounded-md p-5 flex flex-col gap-4
+        text-sm max-h-[40rem] overflow-y-auto"
+      >
         <!-- Context key/values displayed as a list -->
         <div v-for="(value, key) in context" :key="key" class="flex gap-2">
           <span class="font-semibold text-neutral-800">

--- a/app/components/ContextDataCollapsible.vue
+++ b/app/components/ContextDataCollapsible.vue
@@ -1,0 +1,44 @@
+<script setup lang="ts">
+import type { ContextData } from '~/models'
+
+defineProps<{
+  label: string
+  context: ContextData
+}>()
+</script>
+
+<template>
+  <UCollapsible v-if="context">
+    <UButton
+      trailing-icon="i-lucide-chevron-down"
+      size="md"
+      class="group w-fit"
+      color="neutral"
+      variant="soft"
+      :label="label"
+      :ui="{
+        trailingIcon: 'group-data-[state=open]:rotate-180 transition-transform duration-200',
+      }"
+    />
+
+    <template #content>
+      <div class="bg-neutral-100 mt-1.5 rounded-md p-5 flex flex-col gap-4 text-sm">
+        <!-- Context key/values displayed as a list -->
+        <div v-for="(value, key) in context" :key="key" class="flex gap-2">
+          <span class="font-semibold text-neutral-800">
+            {{ key.charAt(0).toUpperCase() + key.slice(1) }}:
+          </span>
+
+          <div v-if="Array.isArray(value)">
+            <ul class="list-disc pl-5">
+              <li v-for="(item, index) in value" :key="index">
+                {{ item }}
+              </li>
+            </ul>
+          </div>
+          <span v-else class="whitespace-pre-line">{{ value }}</span>
+        </div>
+      </div>
+    </template>
+  </UCollapsible>
+</template>

--- a/app/components/QuestionProgress.vue
+++ b/app/components/QuestionProgress.vue
@@ -16,11 +16,17 @@ defineProps<{
         {{ progress }} / {{ max }}
       </div>
     </div>
+
     <UProgress
       :model-value="progress"
       :max="max"
       size="xl"
       status
+      :ui="{
+        root: 'flex-row items-center',
+        base: 'flex-1',
+        status: 'w-fit!',
+      }"
     />
   </div>
 </template>

--- a/app/composables/useEvaluation.ts
+++ b/app/composables/useEvaluation.ts
@@ -7,6 +7,7 @@ import { evaluationStorage } from '@/utils/storage'
 export function useEvaluation(evaluationSession?: EvaluationSession) {
   // Core reactive state
   const items = ref<EvaluationItem[]>([])
+  const questions = ref<Map<number, Question>>(new Map())
   const groupedItems = ref<{ [key: string]: EvaluationItem[] }>({})
   const currentIndex = ref(0)
   const currentItem = ref<EvaluationItem | null>(null)
@@ -50,6 +51,7 @@ export function useEvaluation(evaluationSession?: EvaluationSession) {
       }
     })
 
+    questions.value = questionMap
     items.value = allItems
     groupedItems.value = grouped
 
@@ -212,6 +214,7 @@ export function useEvaluation(evaluationSession?: EvaluationSession) {
   return {
     // State
     items,
+    questions,
     groupedItems,
     currentIndex,
     currentItem,

--- a/app/pages/evaluation/[uuid].vue
+++ b/app/pages/evaluation/[uuid].vue
@@ -92,7 +92,7 @@ const currentQuestionProgress = computed(() => {
     </div>
 
     <div class="flex flex-col gap-8 mt-5">
-      <div class="flex gap-8 justify-between">
+      <div class="flex flex-col sm:flex-row gap-2 sm:gap-8 justify-between">
         <QuestionProgress
           :label="$t('evaluation.progress.current')"
           :progress="currentQuestionProgress"

--- a/app/pages/evaluation/[uuid].vue
+++ b/app/pages/evaluation/[uuid].vue
@@ -17,6 +17,7 @@ if (!session) {
 // Initialize evaluation composable with session
 const {
   items,
+  questions,
   groupedItems,
   currentIndex,
   currentItem,
@@ -113,7 +114,7 @@ const currentQuestionProgress = computed(() => {
       </div>
 
       <!-- Question navigation and context header -->
-      <div class="flex flex-col gap-3">
+      <div class="flex flex-col gap-2">
         <QuestionNavigator
           :is-single-evaluation="isSingleEvaluation"
           :grouped-items="groupedItems"
@@ -124,7 +125,17 @@ const currentQuestionProgress = computed(() => {
           :on-navigate="goToItem"
         />
 
-        <QuestionCard v-if="currentItem" :current-question="currentItem" />
+        <ContextDataCollapsible
+          v-if="currentItem && questions.get(currentItem.questionID)?.context"
+          :label="$t('evaluation.question.displayQuestionContext')"
+          :context="questions.get(currentItem.questionID)!.context!"
+        />
+
+        <QuestionCard
+          v-if="currentItem"
+          :current-question="currentItem"
+          class="mt-1"
+        />
       </div>
 
       <!-- Evaluation navigation and card -->

--- a/app/pages/evaluation/[uuid].vue
+++ b/app/pages/evaluation/[uuid].vue
@@ -83,8 +83,15 @@ const currentQuestionProgress = computed(() => {
 </script>
 
 <template>
-  <div>
-    <div class="flex flex-col gap-8 mt-8">
+  <div class="mt-8">
+    <div class="flex flex-col gap-1.5">
+      <!-- Evaluation title and dataset context button -->
+      <h1 class="font-bold text-xl text-neutral-900">
+        <span>{{ session.name }}</span>
+      </h1>
+    </div>
+
+    <div class="flex flex-col gap-8 mt-5">
       <div class="flex gap-8 justify-between">
         <QuestionProgress
           :label="$t('evaluation.progress.current')"
@@ -93,7 +100,8 @@ const currentQuestionProgress = computed(() => {
         />
         <QuestionProgress
           :label="$t('evaluation.progress.total')"
-          :progress="Object.values(evaluatedItems).filter(item => item.value !== undefined || item.masteryLevel !== undefined).length"
+          :progress="Object.values(evaluatedItems)
+            .filter(item => item.value !== undefined || item.masteryLevel !== undefined).length"
           :max="items.length"
         />
       </div>
@@ -140,7 +148,11 @@ const currentQuestionProgress = computed(() => {
     </div>
 
     <!-- Completion Modal -->
-    <UModal v-model:open="isCompletionModalOpen" title="Evalaution Completed Modal" description="Evaluation Completed Modal">
+    <UModal
+      v-model:open="isCompletionModalOpen"
+      title="Evalaution Completed Modal"
+      description="Evaluation Completed Modal"
+    >
       <template #content>
         <UCard>
           <template #header>

--- a/app/pages/evaluation/[uuid].vue
+++ b/app/pages/evaluation/[uuid].vue
@@ -139,7 +139,7 @@ const currentQuestionProgress = computed(() => {
       </div>
 
       <!-- Evaluation navigation and card -->
-      <div class="flex flex-col gap-3">
+      <div class="flex flex-col gap-2">
         <EvaluationNavigator
           :is-single-evaluation="isSingleEvaluation"
           :grouped-items="groupedItems"
@@ -152,6 +152,12 @@ const currentQuestionProgress = computed(() => {
           :on-navigate="goToItem"
         />
 
+        <ContextDataCollapsible
+          v-if="currentItem?.context"
+          :label="$t('evaluation.question.displayAnswerContext')"
+          :context="currentItem?.context"
+        />
+
         <HybridEvaluationCard
           v-if="currentItem"
           :current-item="currentItem"
@@ -159,6 +165,7 @@ const currentQuestionProgress = computed(() => {
           :evaluated-items="evaluatedItems"
           :evaluation-config="evaluationConfig || undefined"
           :evaluate-generic-and-go-next="isGenericEvaluation ? handleEvaluateAndGoNext : undefined"
+          class="mt-1"
           @update:evaluator-comment="evaluatorComment = $event"
         />
       </div>

--- a/app/pages/evaluation/[uuid].vue
+++ b/app/pages/evaluation/[uuid].vue
@@ -89,9 +89,15 @@ const currentQuestionProgress = computed(() => {
       <h1 class="font-bold text-xl text-neutral-900">
         <span>{{ session.name }}</span>
       </h1>
+
+      <ContextDataCollapsible
+        v-if="session.dataset.context"
+        :label="$t('evaluation.displayContext')"
+        :context="session.dataset.context"
+      />
     </div>
 
-    <div class="flex flex-col gap-8 mt-5">
+    <div class="flex flex-col gap-8 mt-6">
       <div class="flex flex-col sm:flex-row gap-2 sm:gap-8 justify-between">
         <QuestionProgress
           :label="$t('evaluation.progress.current')"

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -191,6 +191,7 @@
     },
     "error": "Error",
     "title": "Evaluation",
-    "subtitle": "Evaluate answers and resume sessions whenever you want"
+    "subtitle": "Evaluate answers and resume sessions whenever you want",
+    "displayContext": "Display the evaluation context"
   }
 }

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -137,7 +137,9 @@
     "question": {
       "title": "Question",
       "answer": "Answer",
-      "submittedAnswer": "Submitted Answer"
+      "submittedAnswer": "Submitted Answer",
+      "displayQuestionContext": "Display the question context",
+      "displayAnswerContext": "Display the answer context"
     },
     "mastery": {
       "NOT_ATTAINED": "Not Attained",

--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -137,7 +137,9 @@
     "question": {
       "title": "Question",
       "answer": "Répondre",
-      "submittedAnswer": "Réponse soumise"
+      "submittedAnswer": "Réponse soumise",
+      "displayQuestionContext": "Afficher le contexte de la question",
+      "displayAnswerContext": "Afficher le contexte de la réponse"
     },
     "mastery": {
       "NOT_ATTAINED": "Non atteint",

--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -191,6 +191,7 @@
     },
     "error": "Erreur",
     "title": "Évaluation",
-    "subtitle": "Évaluez les réponses et reprenez les sessions quand vous le souhaitez"
+    "subtitle": "Évaluez les réponses et reprenez les sessions quand vous le souhaitez",
+    "displayContext": "Afficher le contexte de l'évaluation"
   }
 }


### PR DESCRIPTION
Implements #13.  
UCollapsible` allows to display or hide the context of the dataset, question, or answer to be evaluated.  
A maximum height is set so that too much information is not displayed to the user.

In this issue, I also optimized the space taken up by the progress bars. The percentage is now displayed on the left.