### PR TITLE
Navigation large dataset

### DIFF
--- a/app/components/EvaluationNavigator.vue
+++ b/app/components/EvaluationNavigator.vue
@@ -12,7 +12,8 @@ const props = defineProps<{
   evaluatedItems: {
     [itemId: string]: { value?: any, masteryLevel?: string, comment?: string }
   }
-  onNavigate: (index: number) => void
+  onNavigate: (index: number) => void // FIXME change to (groupIndex: number, itemIndexInGroup: number)
+  // FIXME add current group index for handleNavigation ?
 }>()
 
 const { t } = useI18n()

--- a/app/components/EvaluationNavigator.vue
+++ b/app/components/EvaluationNavigator.vue
@@ -29,9 +29,6 @@ function scrollToActiveItem(itemIndex: number) {
 // Handle navigation and auto-scroll
 function handleNavigation(itemIndexInGroup: number) {
   props.onNavigate(props.currentGroupIndex, itemIndexInGroup)
-  nextTick(() => {
-    scrollToActiveItem(itemIndexInGroup)
-  })
 }
 
 // Watch for current item changes to auto-scroll when navigation happens externally

--- a/app/components/EvaluationNavigator.vue
+++ b/app/components/EvaluationNavigator.vue
@@ -6,14 +6,14 @@ const props = defineProps<{
   groupedItems: { [key: string]: readonly EvaluationItem[] }
   items: readonly EvaluationItem[]
   currentItemGroup: readonly EvaluationItem[]
-  currentAbsoluteItemIndex: number
+  currentGroupIndex: number
   currentItemIndexInGroup: number
-  currentIndex: number
   evaluatedItems: {
     [itemId: string]: { value?: any, masteryLevel?: string, comment?: string }
   }
-  onNavigate: (index: number) => void // FIXME change to (groupIndex: number, itemIndexInGroup: number)
-  // FIXME add current group index for handleNavigation ?
+  onNavigate: (groupIndex: number, itemIndexInGroup: number) => void
+  goToPrevious: () => void
+  goToNext: () => void
 }>()
 
 const { t } = useI18n()
@@ -27,17 +27,15 @@ function scrollToActiveItem(itemIndex: number) {
 }
 
 // Handle navigation and auto-scroll
-function handleNavigation(itemIndex: number) {
-  props.onNavigate(itemIndex)
+function handleNavigation(itemIndexInGroup: number) {
+  props.onNavigate(props.currentGroupIndex, itemIndexInGroup)
   nextTick(() => {
-    // Calculate the index within the current group for scrolling
-    const indexInGroup = itemIndex - (props.currentAbsoluteItemIndex - props.currentItemIndexInGroup)
-    scrollToActiveItem(indexInGroup)
+    scrollToActiveItem(itemIndexInGroup)
   })
 }
 
-// Watch for currentIndex changes to auto-scroll when navigation happens externally
-watch(() => props.currentIndex, (_newIndex) => {
+// Watch for current item changes to auto-scroll when navigation happens externally
+watch(() => [props.currentGroupIndex, props.currentItemIndexInGroup], () => {
   nextTick(() => {
     // For external navigation changes, use the current item index in group
     scrollToActiveItem(props.currentItemIndexInGroup)
@@ -58,16 +56,8 @@ onMounted(() => {
 
 // Shortcuts with arrow keys to navigate
 defineShortcuts({
-  ArrowLeft: () => {
-    if (props.currentIndex > 0) {
-      handleNavigation(props.currentIndex - 1)
-    }
-  },
-  ArrowRight: () => {
-    if (props.currentIndex < props.items.length - 1) {
-      handleNavigation(props.currentIndex + 1)
-    }
-  },
+  ArrowLeft: () => props.goToPrevious(),
+  ArrowRight: () => props.goToNext(),
 })
 </script>
 
@@ -93,10 +83,7 @@ defineShortcuts({
           :item-index="itemIndex + 1"
           :is-current-item="itemIndex === currentItemIndexInGroup"
           :is-item-evaluated="isItemEvaluated(item) ?? false"
-          @click="() => handleNavigation(
-            currentAbsoluteItemIndex - currentItemIndexInGroup // first question in group
-              + itemIndex,
-          )"
+          @click="() => handleNavigation(itemIndex)"
         />
       </div>
     </div>

--- a/app/components/QuestionNavigator.vue
+++ b/app/components/QuestionNavigator.vue
@@ -10,7 +10,8 @@ const props = defineProps<{
   evaluatedItems: {
     [itemId: string]: { value?: any, masteryLevel?: string, comment?: string }
   }
-  onNavigate: (index: number) => void
+  onNavigate: (index: number) => void // FIXME change to (groupIndex: number, itemIndexInGroup: number)
+  // FIXME add current group index for handleNavigation ?
 }>()
 
 const { t } = useI18n()

--- a/app/components/QuestionNavigator.vue
+++ b/app/components/QuestionNavigator.vue
@@ -4,14 +4,15 @@ import type { EvaluationItem } from '~/models'
 const props = defineProps<{
   isSingleEvaluation: boolean
   groupedItems: { [key: string]: readonly EvaluationItem[] }
+  groupKeys: readonly string[]
   items: readonly EvaluationItem[]
   currentItemGroup: readonly EvaluationItem[]
-  currentIndex: number
+  currentItemIndexInGroup: number
+  currentGroupIndex: number
   evaluatedItems: {
     [itemId: string]: { value?: any, masteryLevel?: string, comment?: string }
   }
-  onNavigate: (index: number) => void // FIXME change to (groupIndex: number, itemIndexInGroup: number)
-  // FIXME add current group index for handleNavigation ?
+  onNavigate: (groupIndex: number, itemIndexInGroup: number) => void
 }>()
 
 const { t } = useI18n()
@@ -22,33 +23,37 @@ const questionScrollContainer = ref<HTMLElement>()
 const questionGroupScrollContainer = ref<HTMLElement>()
 
 // Handle navigation and auto-scroll
-function handleNavigation(questionIndex: number, groupIndex?: number) {
-  props.onNavigate(questionIndex)
+function handleSingleNavigation(itemIndex: number) {
+  props.onNavigate(0, itemIndex)
   nextTick(() => {
     scrollToActiveQuestion(
-      props.isSingleEvaluation,
+      true, // single navigation
       questionScrollContainer,
       questionGroupScrollContainer,
-      questionIndex,
+      itemIndex,
       props.currentItemGroup,
       props.groupedItems,
     )
-
-    // scroll to the active question group for grouped evaluations
-    if (!props.isSingleEvaluation && groupIndex !== undefined) {
-      scrollToItem(questionGroupScrollContainer, groupIndex)
-    }
+  })
+}
+function handleGroupNavigation(groupIndex: number) {
+  props.onNavigate(groupIndex, 0)
+  nextTick(() => {
+    scrollToActiveQuestion(
+      false,
+      questionScrollContainer,
+      questionGroupScrollContainer,
+      groupIndex,
+      props.currentItemGroup,
+      props.groupedItems,
+    )
+    scrollToItem(questionGroupScrollContainer, groupIndex)
   })
 }
 
-// Watch for currentIndex changes to auto-scroll when navigation happens externally
-watch(() => props.currentIndex, (newIndex) => {
-  nextTick(() => {
-    scrollToItem(
-      props.isSingleEvaluation ? questionScrollContainer : questionGroupScrollContainer,
-      props.isSingleEvaluation ? newIndex : getGroupIndexForQuestion(newIndex),
-    )
-  })
+// Watch for current item changes to auto-scroll when navigation happens externally
+watch(() => [props.currentGroupIndex, props.currentItemIndexInGroup], () => {
+  scrollToCurrentQuestion()
 }, { immediate: false })
 
 // Check if a question is evaluated by looking for the specific item ID
@@ -58,40 +63,17 @@ function isQuestionEvaluated(question: EvaluationItem) {
   return evaluated && (evaluated.value !== undefined || evaluated.masteryLevel !== undefined)
 }
 
-// Helper function to get group index for a given question index
-function getGroupIndexForQuestion(_questionIndex: number) {
-  const currentGroup = props.currentItemGroup[0]?.questionID
-  if (currentGroup) {
-    const groupNames = Object.keys(props.groupedItems)
-    return groupNames.indexOf(currentGroup.toString())
-  }
-  return 0
-}
-
-function getFirstItemGroupAbsoluteIndex(groupName: string) {
-  const questionGroupKeys
-  = computed(() => Object.keys(props.groupedItems))
-  let index = 0
-
-  for (let groupIndex = 0; groupIndex < questionGroupKeys.value.length; groupIndex++) {
-    const groupKey = questionGroupKeys.value[groupIndex]
-    if (groupKey === groupName) {
-      return { index, groupIndex }
-    }
-    index += groupKey ? props.groupedItems[groupKey]?.length || 0 : 0
-  }
-  return { index: -1, groupIndex: -1 } // not found
-}
-
 // Auto-scroll to current question on mount
-onMounted(() => {
+onMounted(() => scrollToCurrentQuestion())
+
+function scrollToCurrentQuestion() {
   nextTick(() => {
     scrollToItem(
       props.isSingleEvaluation ? questionScrollContainer : questionGroupScrollContainer,
-      props.isSingleEvaluation ? props.currentIndex : getGroupIndexForQuestion(props.currentIndex),
+      props.isSingleEvaluation ? props.currentItemIndexInGroup : props.currentGroupIndex,
     )
   })
-})
+}
 </script>
 
 <template>
@@ -99,7 +81,9 @@ onMounted(() => {
     <!-- Legend -->
     <div class="flex items-center mb-2 gap-1.5 text-sm font-medium text-neutral-900">
       <h3>
-        {{ isSingleEvaluation ? t('evaluation.navigation.overviewAnswers') : t('evaluation.navigation.overviewQuestions') }}
+        {{ isSingleEvaluation
+          ? t('evaluation.navigation.overviewAnswers')
+          : t('evaluation.navigation.overviewQuestions') }}
       </h3>
 
       <NavigatorHelp />
@@ -113,31 +97,26 @@ onMounted(() => {
         class="flex overflow-auto gap-2 p-1"
       >
         <NavigatorItem
-          v-for="(question, questionIndex) in items"
+          v-for="(question, itemIndex) in items"
           :key="question.id"
           button-size="sm"
-          :item-index="`${questionIndex + 1}`"
-          :is-current-item="questionIndex === currentIndex"
+          :item-index="`${itemIndex + 1}`"
+          :is-current-item="itemIndex === currentItemIndexInGroup"
           :is-item-evaluated="isQuestionEvaluated(question) ?? false"
-          @click="() => handleNavigation(questionIndex)"
+          @click="() => handleSingleNavigation(itemIndex)"
         />
       </div>
 
       <!-- Group navigation otherwise -->
       <div v-else ref="questionGroupScrollContainer" class="flex overflow-auto gap-2 p-1">
         <NavigatorItem
-          v-for="(group, groupName) in groupedItems"
-          :key="groupName"
+          v-for="(groupKey, groupIndex) in groupKeys"
+          :key="groupKey"
           button-size="sm"
-          :item-index="`Q${groupName}`"
-          :is-current-item="groupName === currentItemGroup[0]?.questionID.toString()"
-          :is-item-evaluated="group.every(isQuestionEvaluated)"
-          @click="() => {
-            const { index, groupIndex }
-              = getFirstItemGroupAbsoluteIndex(groupName as string)
-
-            handleNavigation(index, groupIndex)
-          }"
+          :item-index="`Q${groupKey}`"
+          :is-current-item="groupIndex === currentGroupIndex"
+          :is-item-evaluated="groupedItems[groupKey]?.every(isQuestionEvaluated) ?? false"
+          @click="() => handleGroupNavigation(groupIndex)"
         />
       </div>
     </div>

--- a/app/composables/useEvaluation.ts
+++ b/app/composables/useEvaluation.ts
@@ -9,6 +9,7 @@ export function useEvaluation(evaluationSession?: EvaluationSession) {
   const items = ref<EvaluationItem[]>([])
   const questions = ref<Map<number, Question>>(new Map())
   const groupedItems = ref<{ [key: string]: EvaluationItem[] }>({})
+  const groupKeys = ref<string[]>([])
   const currentIndex = ref(0)
   const currentItem = ref<EvaluationItem | null>(null)
   const currentItemGroup = ref<EvaluationItem[]>([])
@@ -54,17 +55,18 @@ export function useEvaluation(evaluationSession?: EvaluationSession) {
     questions.value = questionMap
     items.value = allItems
     groupedItems.value = grouped
+    groupKeys.value = Object.keys(grouped)
 
     // Determine if single evaluation:
     // 1. Only 1 question (regardless of how many student answers/items)
     // 2. OR every question has exactly 1 evaluation item
-    isSingleEvaluation.value = Object.keys(grouped).length === 1
+    isSingleEvaluation.value = groupKeys.value.length === 1
       || Object.values(grouped).every(group => group.length === 1)
 
     // Set current item
     if (allItems.length > 0) {
       currentItem.value = allItems[0] || null
-      const firstGroupKey = Object.keys(grouped)[0]
+      const firstGroupKey = groupKeys.value[0]
       if (firstGroupKey) {
         currentItemGroup.value = grouped[firstGroupKey] || []
       }

--- a/app/composables/useEvaluation.ts
+++ b/app/composables/useEvaluation.ts
@@ -11,7 +11,6 @@ export function useEvaluation(evaluationSession?: EvaluationSession) {
   const groupedItems = ref<{ [key: string]: EvaluationItem[] }>({})
   const groupKeys = ref<string[]>([])
   const currentGroupIndex = ref(0)
-  const currentIndex = ref(0)
   const currentItemIndexInGroup = ref(0)
   const currentItem = ref<EvaluationItem | null>(null)
   const currentItemGroup = ref<EvaluationItem[]>([])
@@ -247,7 +246,8 @@ export function useEvaluation(evaluationSession?: EvaluationSession) {
     items,
     questions,
     groupedItems,
-    currentIndex,
+    groupKeys,
+    currentGroupIndex,
     currentItem,
     currentItemGroup,
     evaluatedItems,

--- a/app/composables/useEvaluation.ts
+++ b/app/composables/useEvaluation.ts
@@ -10,7 +10,9 @@ export function useEvaluation(evaluationSession?: EvaluationSession) {
   const questions = ref<Map<number, Question>>(new Map())
   const groupedItems = ref<{ [key: string]: EvaluationItem[] }>({})
   const groupKeys = ref<string[]>([])
+  const currentGroupIndex = ref(0)
   const currentIndex = ref(0)
+  const currentItemIndexInGroup = ref(0)
   const currentItem = ref<EvaluationItem | null>(null)
   const currentItemGroup = ref<EvaluationItem[]>([])
   const evaluatedItems = ref<{ [itemId: string]: { value?: any, masteryLevel?: string, comment?: string } }>({})
@@ -64,12 +66,11 @@ export function useEvaluation(evaluationSession?: EvaluationSession) {
       || Object.values(grouped).every(group => group.length === 1)
 
     // Set current item
-    if (allItems.length > 0) {
-      currentItem.value = allItems[0] || null
-      const firstGroupKey = groupKeys.value[0]
-      if (firstGroupKey) {
-        currentItemGroup.value = grouped[firstGroupKey] || []
-      }
+    if (allItems.length > 0 && groupKeys.value.length > 0 && groupKeys.value[0]) {
+      currentGroupIndex.value = 0
+      currentItemGroup.value = grouped[groupKeys.value[0]] || []
+      currentItemIndexInGroup.value = 0
+      currentItem.value = currentItemGroup.value[0] ?? null
     }
 
     // Load existing evaluation results
@@ -98,40 +99,54 @@ export function useEvaluation(evaluationSession?: EvaluationSession) {
   }
 
   // Navigation functions
-  function goToItem(index: number) {
-    if (index >= 0 && index < items.value.length) {
-      currentIndex.value = index
-      const item = items.value[index]
+  function goToItem(groupIndex: number, itemIndexInGroup: number) {
+    const groupKey = groupKeys.value[groupIndex]
+    if (groupIndex >= 0 && groupIndex < groupKeys.value.length && groupKey // valid group index
+      && itemIndexInGroup >= 0
+      && itemIndexInGroup < (groupedItems.value[groupKey]?.length ?? 0)) { // valid item index
+      currentGroupIndex.value = groupIndex
+      currentItemGroup.value = groupedItems.value[groupKey] || []
+      currentItemIndexInGroup.value = itemIndexInGroup
+      currentItem.value = currentItemGroup.value[itemIndexInGroup] ?? null
+
+      // Load existing evaluation comment for this item (don't create new state)
+      const item = currentItem.value
       if (item) {
-        currentItem.value = item
-
-        // Update current item group
-        const questionId = item.questionID
-        if (questionId) {
-          currentItemGroup.value = groupedItems.value[questionId.toString()] || []
-        }
-
-        // Load existing evaluation comment for this item (don't create new state)
         const existing = evaluatedItems.value[item.id.toString()]
-        if (existing && existing.comment) {
-          evaluatorComment.value = existing.comment
-        }
-        else {
-          evaluatorComment.value = ''
-        }
+        evaluatorComment.value = existing?.comment || ''
       }
     }
   }
 
   function goToNextItem() {
-    if (currentIndex.value < items.value.length - 1) {
-      goToItem(currentIndex.value + 1)
+    const groupIndex = currentGroupIndex.value
+    const itemIndexInGroup = currentItemIndexInGroup.value
+    const group = groupKeys.value[groupIndex]
+      ? (groupedItems.value[groupKeys.value[groupIndex]] ?? [])
+      : []
+
+    if (itemIndexInGroup < group.length - 1) {
+      goToItem(groupIndex, itemIndexInGroup + 1)
+    }
+    else if (groupIndex < groupKeys.value.length - 1) {
+      goToItem(groupIndex + 1, 0)
     }
   }
 
   function goToPreviousItem() {
-    if (currentIndex.value > 0) {
-      goToItem(currentIndex.value - 1)
+    const groupIndex = currentGroupIndex.value
+    const itemIndexInGroup = currentItemIndexInGroup.value
+
+    if (itemIndexInGroup > 0) {
+      goToItem(groupIndex, itemIndexInGroup - 1)
+    }
+    else if (groupIndex > 0) {
+      const previousGroupKey = groupKeys.value[groupIndex - 1]
+      const previousGroup = previousGroupKey
+        ? groupedItems.value[previousGroupKey] || []
+        : []
+
+      goToItem(groupIndex - 1, previousGroup.length - 1)
     }
   }
 
@@ -202,16 +217,30 @@ export function useEvaluation(evaluationSession?: EvaluationSession) {
     return evaluation && (evaluation.value !== undefined || evaluation.masteryLevel !== undefined)
   })
 
-  const currentQuestionIndexInGroup = computed(() => {
-    if (!currentItem.value || !currentItemGroup.value.length)
-      return 0
-    return currentItemGroup.value.findIndex(item => item.id === currentItem.value?.id)
+  const currentAbsoluteQuestionIndex = computed(() => { // index in all groupedItems values
+    let previousItemsCount = 0
+    // Sum of all previous groups' items
+    for (let i = 0; i < currentGroupIndex.value; i++) {
+      const groupKey = groupKeys.value[i]
+      previousItemsCount += groupKey
+        ? (groupedItems.value[groupKey]?.length ?? 0)
+        : 0
+    }
+    return previousItemsCount + currentItemIndexInGroup.value
   })
 
-  const currentAbsoluteQuestionIndex = computed(() => currentIndex.value)
+  const hasNextItem = computed(() => {
+    const groupIndex = currentGroupIndex.value
+    const itemIndexInGroup = currentItemIndexInGroup.value
+    const groupKey = groupKeys.value[groupIndex]
+    const group = groupKey ? groupedItems.value[groupKey] || [] : []
 
-  const hasNextItem = computed(() => currentIndex.value < items.value.length - 1)
-  const hasPreviousItem = computed(() => currentIndex.value > 0)
+    return (itemIndexInGroup < group.length - 1) // has next item in current group
+      || (groupIndex < groupKeys.value.length - 1) // has next group
+  })
+  const hasPreviousItem = computed(() => {
+    return currentItemIndexInGroup.value > 0 || currentGroupIndex.value > 0
+  })
 
   return {
     // State
@@ -224,11 +253,11 @@ export function useEvaluation(evaluationSession?: EvaluationSession) {
     evaluatedItems,
     evaluatorComment,
     isSingleEvaluation,
+    currentItemIndexInGroup,
 
     // Computed
     progress,
     isCurrentItemEvaluated,
-    currentQuestionIndexInGroup,
     currentAbsoluteQuestionIndex,
     hasNextItem,
     hasPreviousItem,

--- a/app/pages/evaluation/[uuid].vue
+++ b/app/pages/evaluation/[uuid].vue
@@ -25,7 +25,7 @@ const {
   evaluatedItems,
   evaluatorComment,
   isSingleEvaluation,
-  currentQuestionIndexInGroup,
+  currentItemIndexInGroup,
   currentAbsoluteQuestionIndex,
   goToItem,
   evaluateAndGoNext,
@@ -146,7 +146,7 @@ const currentQuestionProgress = computed(() => {
           :items="items"
           :current-item-group="currentItemGroup"
           :current-absolute-item-index="currentAbsoluteQuestionIndex"
-          :current-item-index-in-group="currentQuestionIndexInGroup"
+          :current-item-index-in-group="currentItemIndexInGroup"
           :current-index="currentIndex"
           :evaluated-items="evaluatedItems"
           :on-navigate="goToItem"

--- a/app/pages/evaluation/[uuid].vue
+++ b/app/pages/evaluation/[uuid].vue
@@ -19,15 +19,17 @@ const {
   items,
   questions,
   groupedItems,
-  currentIndex,
+  groupKeys,
+  currentGroupIndex,
   currentItem,
   currentItemGroup,
   evaluatedItems,
   evaluatorComment,
   isSingleEvaluation,
   currentItemIndexInGroup,
-  currentAbsoluteQuestionIndex,
   goToItem,
+  goToPreviousItem,
+  goToNextItem,
   evaluateAndGoNext,
 } = useEvaluation(session)
 
@@ -118,9 +120,11 @@ const currentQuestionProgress = computed(() => {
         <QuestionNavigator
           :is-single-evaluation="isSingleEvaluation"
           :grouped-items="groupedItems"
+          :group-keys="groupKeys"
           :items="items"
+          :current-group-index="currentGroupIndex"
+          :current-item-index-in-group="currentItemIndexInGroup"
           :current-item-group="currentItemGroup"
-          :current-index="currentIndex"
           :evaluated-items="evaluatedItems"
           :on-navigate="goToItem"
         />
@@ -145,11 +149,12 @@ const currentQuestionProgress = computed(() => {
           :grouped-items="groupedItems"
           :items="items"
           :current-item-group="currentItemGroup"
-          :current-absolute-item-index="currentAbsoluteQuestionIndex"
+          :current-group-index="currentGroupIndex"
           :current-item-index-in-group="currentItemIndexInGroup"
-          :current-index="currentIndex"
           :evaluated-items="evaluatedItems"
           :on-navigate="goToItem"
+          :go-to-previous="goToPreviousItem"
+          :go-to-next="goToNextItem"
         />
 
         <ContextDataCollapsible


### PR DESCRIPTION
Fixes #31.  

Previously, navigation was done on the `allItems` list, which caused problems if the responses in the dataset were not grouped by question and in the order of the question indexes.
Thus, I focused on the groups: to navigate to the next item, for example, you have to go to the next index in the same group — or move on to the next group.

❗This is a significant change affecting the display of items, changing groups, navigation, and scrolling. I may have forgotten some specific cases...