### PR TITLE
fix: prevent auto-advance when comments are required

### DIFF
--- a/app/components/HybridEvaluationCard.vue
+++ b/app/components/HybridEvaluationCard.vue
@@ -93,8 +93,7 @@ const canConfirmEvaluation = computed(() => {
   return hasValue && hasRequiredComment
 })
 
-// Auto-advance: when comments are not allowed or not required and empty,
-// selecting a value auto-confirms
+// Auto-advance: only when comments are not allowed at all
 const shouldAutoAdvance = computed(() => {
   return !commentsAllowed.value
 })
@@ -150,11 +149,7 @@ useEvaluationShortcuts({
       selectValue(options[index]!.value)
     }
   },
-  onConfirm: () => {
-    if (shouldAutoAdvance.value) {
-      confirmEvaluation()
-    }
-  },
+  onConfirm: () => confirmEvaluation(),
   onIncrement: () => incrementScore(),
   onDecrement: () => decrementScore(),
   optionCount: computed(() => evaluationOptions.value.length),

--- a/app/components/HybridEvaluationCard.vue
+++ b/app/components/HybridEvaluationCard.vue
@@ -150,7 +150,11 @@ useEvaluationShortcuts({
       selectValue(options[index]!.value)
     }
   },
-  onConfirm: () => {if (shouldAutoAdvance){confirmEvaluation()}},
+  onConfirm: () => {
+    if (shouldAutoAdvance.value) {
+      confirmEvaluation()
+    }
+  },
   onIncrement: () => incrementScore(),
   onDecrement: () => decrementScore(),
   optionCount: computed(() => evaluationOptions.value.length),

--- a/app/components/HybridEvaluationCard.vue
+++ b/app/components/HybridEvaluationCard.vue
@@ -96,7 +96,7 @@ const canConfirmEvaluation = computed(() => {
 // Auto-advance: when comments are not allowed or not required and empty,
 // selecting a value auto-confirms
 const shouldAutoAdvance = computed(() => {
-  return !commentsAllowed.value || (!commentsRequired.value && !localComment.value?.trim())
+  return !commentsAllowed.value
 })
 
 function onCommentUpdate(value: string) {
@@ -150,7 +150,7 @@ useEvaluationShortcuts({
       selectValue(options[index]!.value)
     }
   },
-  onConfirm: () => confirmEvaluation(),
+  onConfirm: () => {if (shouldAutoAdvance){confirmEvaluation()}},
   onIncrement: () => incrementScore(),
   onDecrement: () => decrementScore(),
   optionCount: computed(() => evaluationOptions.value.length),


### PR DESCRIPTION
Dans le cas là où les commentaires sont optionnel,ou obligatoire, on ne passe pas vers la prochaine question dès que le `score` est choisi.