### PR TITLE
Annuler une configuration

### DIFF
--- a/app/components/EvaluationConfigModal.vue
+++ b/app/components/EvaluationConfigModal.vue
@@ -88,7 +88,6 @@ function validateAndSave() {
 }
 
 function cancel() {
-  emit('update:modelValue', null)
   isOpen.value = false
 }
 

--- a/app/components/EvaluationConfigModal.vue
+++ b/app/components/EvaluationConfigModal.vue
@@ -27,6 +27,14 @@ const validationErrors = ref<string[]>([])
 const activeTab = ref<string>('basic')
 const isSaving = ref(false)
 
+function onAfterLeave() {
+  // Réinitialiser tout les valeurs une fois que le modal est fermé
+  localConfig.value = null
+  validationErrors.value = []
+  isSaving.value = false
+  activeTab.value = 'basic'
+}
+
 // Initialize local config when props change
 watch(() => props.modelValue, (newConfig) => {
   if (newConfig) {
@@ -80,10 +88,6 @@ function validateAndSave() {
 }
 
 function cancel() {
-  localConfig.value = null
-  validationErrors.value = []
-  isSaving.value = false
-  activeTab.value = 'basic' // Reset tab to default
   emit('update:modelValue', null)
   isOpen.value = false
 }
@@ -132,18 +136,13 @@ watch([isOpen, masteryLevelsList], async ([isOpenNow, list]) => {
     )
   }
   else {
-    // Reset all state when modal is closed
-    localConfig.value = null
-    validationErrors.value = []
-    isSaving.value = false
-    activeTab.value = 'basic'
     sortableInstance.value = null
   }
 })
 </script>
 
 <template>
-  <UModal v-model:open="isOpen" title="Evaluation Config Modal" description="Evaluation Config Modal">
+  <UModal v-model:open="isOpen" title="Evaluation Config Modal" description="Evaluation Config Modal" @after:leave="onAfterLeave">
     <template #content>
       <UCard>
         <template #header>

--- a/app/components/EvaluationConfigModal.vue
+++ b/app/components/EvaluationConfigModal.vue
@@ -28,7 +28,7 @@ const activeTab = ref<string>('basic')
 const isSaving = ref(false)
 
 function onAfterLeave() {
-  // Réinitialiser tout les valeurs une fois que le modal est fermé
+  // Reset modal values once the modal is closed
   localConfig.value = null
   validationErrors.value = []
   isSaving.value = false

--- a/app/components/HybridEvaluationCard.vue
+++ b/app/components/HybridEvaluationCard.vue
@@ -75,14 +75,14 @@ const isScoreEvaluation = computed(() => {
 
 const commentsAllowed = computed(() => {
   if (props.evaluationConfig) {
-    return props.evaluationConfig.settings.allowComments
+    return props.evaluationConfig.settings.allowComments ?? true
   }
   return true
 })
 
 const commentsRequired = computed(() => {
   if (props.evaluationConfig) {
-    return props.evaluationConfig.settings.requireComments
+    return props.evaluationConfig.settings.requireComments ?? false
   }
   return false
 })
@@ -150,7 +150,7 @@ useEvaluationShortcuts({
       selectValue(options[index]!.value)
     }
   },
-  onConfirm: () => {if (shouldAutoAdvance){confirmEvaluation()}},
+  onConfirm: () => { confirmEvaluation() },
   onIncrement: () => incrementScore(),
   onDecrement: () => decrementScore(),
   optionCount: computed(() => evaluationOptions.value.length),


### PR DESCRIPTION
While cancelling a configuration, we used to reset the modal state before closing the modal, so it used to jump to the first step while waiting for the code to finish the reset.
Now we reset the values of the modal once it is closed, so we prevent the jump to the first step.


[resultVideo.webm](https://github.com/user-attachments/assets/531874d5-3f0c-4a6e-ac85-619b16670e8a)
